### PR TITLE
Expose react-lazyload's forceCheck method (to work around #106)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import "nodelist-foreach-polyfill";
+import { forceCheck } from "react-lazyload";
 
 import boot from "./boot";
 import Hub, { Listener } from "./helpers/hub";
@@ -19,6 +20,7 @@ function bootstrapDCLightExercises() {
 
 (global as any).bootstrapDCLightExercises = bootstrapDCLightExercises;
 (global as any).initAddedDCLightExercises = bootstrapDCLightExercises;
+(global as any).forceDCLightLazyLoadCheck = forceCheck;
 
 document.addEventListener("DOMContentLoaded", bootstrapDCLightExercises);
 


### PR DESCRIPTION
This is a minimal viable workaround for the lazy loading issues noted in #106. In certain cases with dynamic content, the lazy loading doesn't work and the exercises aren't loading.

An easy workaround is exposing `react-lazyload`'s built in `forceCheck` method, which callers could use to force a refresh in cases where lazy loading isn't working. I think disabling lazy-loading entirely might be a more sensible option, but it also seemed like a slightly larger change. Feel free to do that instead if it seems easier.

**Please note this PR has not been tested, because I had build issues and was not able to quickly work past them.** Somebody should test this carefully and make sure it actually works 🙂