### PR TITLE
Add option to disable lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ version, click [here](https://github.com/datacamp/datacamp-light/tree/d0c7ae4afc
   * [Solution](#solution)
   * [Submission Correctness Test (SCT)](#submission-correctness-test-sct)
   * [Hint](#hint)
+  * [Other Options](#other-options)
 - [How does it work?](#how-does-it-work)
 - [Contributing](#contributing)
   * [Dependencies](#dependencies)
@@ -239,6 +240,10 @@ It is possible for the hint to contain for instance `<code>` tags as is the case
 
 
 
+### Other Options
+
+- Add a `data-show-run-button` attribute to always show the "Run" button, so your visitors can try out the code without submitting it.
+- Add a `data-no-lazy-loading` attribute to load all exercises as soon as the page is loaded, instead of waiting for the user to scroll down to them. This may cause performance issues, but can fix compatibility problems with iFrame-based pages.
 
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -542,6 +542,9 @@
 
         <dt><code>data-show-run-button</code></dt>
         <dd>Add this property to always show the &ldquo;Run&rdquo; button, so the student can execute his code without submitting it.</dd>
+
+        <dt><code>data-no-lazy-load</code></dt>
+        <dd>Add this property to load all exercises immediately, without waiting for them to become visible on the page. This will reduce performance, but can fix compatibility issues with iFrame-based pages.</dd>
       </dl>
 
 

--- a/src/boot.tsx
+++ b/src/boot.tsx
@@ -58,6 +58,9 @@ export default (element: HTMLDivElement, hub: Hub) => {
     const showRunButton =
       element.hasAttribute("data-show-run-button") &&
       element.getAttribute("data-show-run-button").toLowerCase() !== "false";
+    const noLazyLoad =
+      element.hasAttribute("data-no-lazy-load") &&
+      element.getAttribute("data-no-lazy-load").toLowerCase() !== "false";
 
     // Get settings
     Object.assign(settings, {
@@ -68,6 +71,7 @@ export default (element: HTMLDivElement, hub: Hub) => {
       sct: getText("sct"),
       solution: getText("solution"),
       showRunButton: showRunButton,
+      noLazyLoad: noLazyLoad,
     });
   }
 
@@ -87,22 +91,32 @@ export default (element: HTMLDivElement, hub: Hub) => {
 
   element.style.height = `${settings.height}px`;
 
-  render(
-    <LazyLoad
-      height={settings.height}
-      offset={200}
-      once
-      placeholder={<Placeholder />}
-      debounce={50}
-    >
+  const getAppContainer = () => {
+    return (
       <AppContainer>
         <Provider store={store}>
           <App height={settings.height} language={settings.language} />
         </Provider>
       </AppContainer>
-    </LazyLoad>,
-    element
-  );
+    );
+  };
+
+  if (settings.noLazyLoad) {
+    render(getAppContainer(), element);
+  } else {
+    render(
+      <LazyLoad
+        height={settings.height}
+        offset={200}
+        once
+        placeholder={<Placeholder />}
+        debounce={50}
+      >
+        {getAppContainer()}
+      </LazyLoad>,
+      element
+    );
+  }
 
   store.dispatch(setExercise(settings));
   store.dispatch(updateCode(settings.sample_code));


### PR DESCRIPTION
# Summary

Adds the `data-no-lazy-load` option, which renders the DCL widget without using `react-lazyload`.

# Details

This option is intended to fix issues (reported in #106) of DCL not loading on certain pages. Those issues are related to our lazy-loading library, probably caused by an interaction with iframe-based pages (i.e. react-lazyload doesn't properly detect visibility when it's loaded in a fixed-height frame). In our use-case, at least, enabling this option resolves our issues.

I've tried to follow the code patterns set by the `data-show-run-button` option. I also added some simple docs, but feel free to drop them or modify them if they don't seem suitable.

# Testing

I've tested this manually and it appears to work, and fix our issues. To test, just create a DCL widget with a `data-no-lazy-load` attribute. If you want to see how it affects iFrame viewing issues, just create a large fixed-height iFrame and fill it up with DCL widgets.

No automated tests, unfortunately, because: 1) I wasn't sure how to cleanly test for the absence of lazy-loading, 2) I'm unfamiliar with your testing structure and where this would fit in, and 3) I noticed that there were no tests for `data-show-run-button` so I thought I could get away with it 😉