### PR TITLE
Move submit button for clarity

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -86,6 +86,16 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
             Solution
           </Button>
         )}
+        {this.props.language !== "shell" &&
+        (!this.props.solution || this.props.showRunButton) ? (
+          <Button
+            size="small"
+            onClick={this.onRun}
+            disabled={this.props.isSessionBroken || this.props.isSessionBusy}
+          >
+            Run
+          </Button>
+        ) : null}
         {this.props.language !== "shell" && this.props.sct ? (
           <Button
             size="small"
@@ -94,17 +104,6 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
             disabled={this.props.isSessionBroken || this.props.isSessionBusy}
           >
             Submit
-          </Button>
-        ) : null}
-        {this.props.language !== "shell" &&
-        (!this.props.solution || this.props.showRunButton) ? (
-          <Button
-            size="small"
-            type="primary"
-            onClick={this.onRun}
-            disabled={this.props.isSessionBroken || this.props.isSessionBusy}
-          >
-            Run
           </Button>
         ) : null}
         <BackendStatus className={styles.status} />


### PR DESCRIPTION
# Summary

Moves the submit button to the far right in the footer and changes the color of the Run button to be secondary not primary. 

# Details

The current way the buttons are set up makes it somewhat unintuitive for some students to know which button to click to make sure their answer is graded. Making the Run button the same color as the Hint and Solution buttons separates it visually from the Submit button. For consistency the run button is moved left of the Submit button toward the Hint and Solution buttons. This makes it obvious to students that the Submit button is different from the Hint, Run, and Solution buttons