### PR TITLE
Add option to hide solution before submitting

### DIFF
--- a/src/boot.tsx
+++ b/src/boot.tsx
@@ -59,6 +59,11 @@ export default (element: HTMLDivElement, hub: Hub) => {
       element.hasAttribute("data-show-run-button") &&
       element.getAttribute("data-show-run-button").toLowerCase() !== "false";
 
+    const showSolutionBefore =
+      !element.hasAttribute("data-show-solution-before") ||
+      element.getAttribute("data-show-solution-before").toLowerCase() !==
+        "false";
+
     // Get settings
     Object.assign(settings, {
       hint: getHint(),
@@ -68,6 +73,7 @@ export default (element: HTMLDivElement, hub: Hub) => {
       sct: getText("sct"),
       solution: getText("solution"),
       showRunButton: showRunButton,
+      showSolutionBefore: showSolutionBefore,
     });
   }
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,6 +18,7 @@ export interface IFooterProps extends React.Props<Footer> {
   isSessionBusy?: boolean;
   hint?: string;
   solution?: string;
+  showSolutionBefore?: boolean;
   showSolutionButton?: boolean;
   showRunButton?: boolean;
   sct?: string;
@@ -26,6 +27,7 @@ export interface IFooterProps extends React.Props<Footer> {
 
 interface IFooterState {
   isHintPressed: boolean;
+  isSubmitted: boolean;
 }
 
 export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
@@ -35,6 +37,7 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
     onSubmit: noop,
     isSessionBroken: false,
     isSessionBusy: false,
+    showSolutionBefore: true,
     showSolutionButton: false,
     showRunButton: false,
   };
@@ -45,6 +48,7 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
     super();
     this.state = {
       isHintPressed: false,
+      isSubmitted: false,
     };
 
     this.onShowHint = this.onShowHint.bind(this);
@@ -66,6 +70,9 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
   }
 
   onSubmit() {
+    this.setState({
+      isSubmitted: true,
+    });
     this.props.onSubmit({
       command: "submit",
     });
@@ -80,6 +87,7 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
           </Button>
         ) : null}
         {this.props.solution &&
+        (this.props.showSolutionBefore || this.state.isSubmitted) &&
         this.props.showSolutionButton &&
         (!this.props.hint || this.state.isHintPressed) && (
           <Button size="small" onClick={this.props.onShowSolution}>

--- a/src/containers/Footer.tsx
+++ b/src/containers/Footer.tsx
@@ -11,6 +11,7 @@ import {
   selectHint,
   selectSolution,
   selectSct,
+  selectShowSolutionBefore,
   selectShowRunButton,
   selectLanguage,
 } from "../redux/exercise";
@@ -29,6 +30,7 @@ const mapStateToProps: MapStateToProps<IFooterProps, IOwnProps> = (
   isSessionBusy: selectBackendSessionIsBusy(state),
   hint: selectHint(state),
   solution: selectSolution(state),
+  showSolutionBefore: selectShowSolutionBefore(state),
   showRunButton: selectShowRunButton(state),
   sct: selectSct(state),
   language: selectLanguage(state),

--- a/src/index.html
+++ b/src/index.html
@@ -99,6 +99,22 @@
 
     <div class="exercise">
       <div class="title">
+        <h2>Hide solution until after submission</h2>
+      </div>
+      <div data-datacamp-exercise data-lang="r" data-height="500" data-show-solution-before="false" id="r-exercise">
+        <code data-type="pre-exercise-code"># no pec</code>
+        <code data-type="sample-code">
+          # Note that the solution tab is not available until after Submit is clicked
+        </code>
+        <code data-type="solution">
+          # Solution available after Submit only
+        </code>
+        <code data-type="sct"># no sct</code>
+      </div>
+    </div>
+
+    <div class="exercise">
+      <div class="title">
         <h2>Python playground with a plot</h2>
         <p>If you omit the <code>sct</code> (sample correctness test), you can just use DataCamp Light to play with the code.</p>
       </div>

--- a/src/redux/exercise.ts
+++ b/src/redux/exercise.ts
@@ -27,6 +27,7 @@ export const setExercise = createAction<{
   sample_code?: string;
   sct: string;
   solution: string;
+  showSolutionBefore: boolean;
   showRunButton: boolean;
 }>("SET_EXERCISE");
 
@@ -54,6 +55,7 @@ export interface IExerciseState {
   sct: string;
   solution: string;
   type: ExerciseType;
+  showSolutionBefore: boolean;
   showSolutionButton: boolean;
   showRunButton: boolean;
   shellProxy?: string;
@@ -71,6 +73,7 @@ const initialState: IExerciseState = {
   sct: "",
   solution: "",
   type: "NormalExercise",
+  showSolutionBefore: true,
   showSolutionButton: false,
   showRunButton: false,
   shellProxy: "",
@@ -133,6 +136,9 @@ export const selectSolution = (state: State) =>
   selectExercise(state).get("solution");
 
 export const selectType = (state: State) => selectExercise(state).get("type");
+
+export const selectShowSolutionBefore = (state: State) =>
+  selectExercise(state).get("showSolutionBefore");
 
 export const selectShowRunButton = (state: State) =>
   selectExercise(state).get("showRunButton");


### PR DESCRIPTION
# Summary

Adds a setting to remove the solution from view before submitting an answer. Accomplished by adding a `data-show-solution-before = "false"` setting to the setup and results in hiding the solution button until after the Submit button has been pressed.

# Details

In our use of the DataCamp modules we would like students to first attempt to make an answer before being shown the solution we are grading them against. See #100 for a very similar use case where another of our team members requested to hide the solution altogether.

With this I essentially followed the patterns with the `show-run-button` option for adding the option, and then added a boolean state variable to flag when the item has been submitted.

