### PR TITLE
[LE-70] - Don't import babel-polyfill if it has already been loaded

### DIFF
--- a/configs/webpack.common.js
+++ b/configs/webpack.common.js
@@ -38,7 +38,7 @@ module.exports = {
   stats: "errors-only",
 
   entry: {
-    main: ["babel-polyfill", path.resolve(config.root, "src", "index.ts")],
+    main: [path.resolve(config.root, "src", "index.ts")],
   },
 
   output: {

--- a/src/helpers/polyfill.ts
+++ b/src/helpers/polyfill.ts
@@ -1,0 +1,3 @@
+if (!(global as any)._babelPolyfill) {
+  require("babel-polyfill");
+}

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
         margin: 50px;
       }
     </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.2.5/polyfill.js"></script>
   </head>
   <body>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import "./helpers/polyfill";
 import "nodelist-foreach-polyfill";
 
 import boot from "./boot";


### PR DESCRIPTION
@nunorafaelrocha there are three potential fixes for this.

1. Current suggested fix: This PR checks the global scope for babel-polyfill only loads it if doesn't exist.

2. Completely remove the `babel-polyfill` in `datacamp-light` and place the responsibility of polyfilling on the consumers of `datacamp-light` since we are already supporting the last 2 browser versions. The problem with this solution is that it would cause a breaking change for those users current relying on the `babel-polyfill` in older environments.

3. Dig into why `babel-plugin-transform-runtime` doesn't work as expected. @rv2e and I both hit the same error and opted to go with option `1` for the time being to get this issue fixed quickly.

@nunorafaelrocha Do you have any thoughts or should we move forward with this fix?