### PR TITLE
[LE-57] Added explanation for how to hide config code before exercises are loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ It is possible for the hint to contain for instance `<code>` tags as is the case
 
 - Add a `data-show-run-button` attribute to always show the "Run" button, so your visitors can try out the code without submitting it.
 - Add a `data-no-lazy-loading` attribute to load all exercises as soon as the page is loaded, instead of waiting for the user to scroll down to them. This may cause performance issues, but can fix compatibility problems with iFrame-based pages.
+- Add the following css to the styling of your page to hide the configuration code of the exercises until they are loaded:
+```css
+[data-datacamp-exercise] {
+  visibility: hidden;
+}
+```
 
 
 

--- a/docs/example.html
+++ b/docs/example.html
@@ -8,6 +8,10 @@
     .exercise {
       margin: 50px;
     }
+
+    [data-datacamp-exercise] {
+        visibility: hidden;
+      }
   </style>
 
   <script async src="https://cdn.datacamp.com/dcl-react-dev.js.gz"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -167,6 +167,10 @@
       pre {
         max-width: 100%;
       }
+
+      [data-datacamp-exercise] {
+        visibility: hidden;
+      }
     </style>
 
   </head>

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,10 @@
       .exercise {
         margin: 50px;
       }
+      
+      [data-datacamp-exercise] {
+        visibility: hidden;
+      }
     </style>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.2.5/polyfill.js"></script>
   </head>


### PR DESCRIPTION
In response to issue #108 I added explanation to the docs of how you can hide the initial configuration code of the exercises until they are loaded.

I was able to fix the visible code by adding the `visibility: hidden` style to the exercises and using [extract-text-webpack-plugin](https://github.com/webpack-contrib/extract-text-webpack-plugin) to extract the CSS into a separate file. This way, the styling gets applied before the Javascript bundle is loaded and hides the config code initially.

However, since this results in a separate CSS file instead of a single javascript bundle that can be included, it's not a viable option and it's better to just add some style to the page on which exercises are included.