### PR TITLE
[LE-827] Enabled python version and packages selection

### DIFF
--- a/src/boot.tsx
+++ b/src/boot.tsx
@@ -16,6 +16,7 @@ import Hub from "./helpers/hub";
 import uuid from "./helpers/uuid";
 import { setExercise, updateCode, setId, setListener } from "./redux/exercise";
 import createStore from "./redux/store";
+import * as _ from "lodash";
 
 export default (element: HTMLDivElement, hub: Hub) => {
   const storeEnhancer = composeWithDevTools(
@@ -23,19 +24,26 @@ export default (element: HTMLDivElement, hub: Hub) => {
   );
 
   const getPackages = (packages: string) => {
-    if (packages){
-      return `from dcl_package_manager import install_packages; install_packages([${formatPackages(packages)}])\n`;
+    if (_.isNil(packages) || _.trim(packages) === "") {
+      return "";
     }
-    return "";
+    return `from dcl_package_manager import install_packages; install_packages([${formatPackages(
+      packages
+    )}])\n`;
   };
 
   const formatPackages = (packages: string) => {
-    return packages.split(",").reduce((accumulator, singlePackage) =>  `${accumulator}'${singlePackage}',` , "");
-  }
+    return packages
+      .split(",")
+      .reduce(
+        (accumulator, singlePackage) => `${accumulator}'${singlePackage}',`,
+        ""
+      );
+  };
 
   let settings: any = {
     id: element.id,
-    height: parseInt(element.getAttribute("data-height") || "auto", 10),
+    height: parseInt(element.getAttribute("data-height") || "auto", 10)
   };
 
   if (element.getAttribute("data-encoded")) {
@@ -43,7 +51,8 @@ export default (element: HTMLDivElement, hub: Hub) => {
     settings.hint = exercise.hint;
     settings.language = exercise.language;
     settings.lang_version = exercise.lang_version;
-    settings.pre_exercise_code = getPackages(exercise.packages) + exercise.pre_exercise_code;
+    settings.pre_exercise_code =
+      getPackages(exercise.packages) + exercise.pre_exercise_code;
     settings.sample_code = exercise.sample || exercise.sample_code;
     settings.sct = exercise.sct;
     settings.solution = exercise.solution;
@@ -78,13 +87,16 @@ export default (element: HTMLDivElement, hub: Hub) => {
     Object.assign(settings, {
       hint: getHint(),
       language: (element.getAttribute("data-lang") || "r") as Language,
-      lang_version: element.getAttribute("lang-version"),
-      pre_exercise_code: getPackages(element.getAttribute("packages")) + getText("pre-exercise-code"),
+      lang_version: element.getAttribute("data-lang-version"),
+      packages: element.getAttribute("data-packages"),
+      pre_exercise_code: 
+        getPackages(element.getAttribute("data-packages")) +
+        getText("pre-exercise-code"),
       sample_code: getText("sample-code"),
       sct: getText("sct"),
       solution: getText("solution"),
       showRunButton: showRunButton,
-      noLazyLoad: noLazyLoad,
+      noLazyLoad: noLazyLoad
     });
   }
 

--- a/src/boot.tsx
+++ b/src/boot.tsx
@@ -22,6 +22,17 @@ export default (element: HTMLDivElement, hub: Hub) => {
     applyMiddleware(createEpicMiddleware(rootEpic))
   );
 
+  const getPackages = (packages: string) => {
+    if (packages){
+      return `from dcl_package_manager import install_packages; install_packages([${formatPackages(packages)}])\n`;
+    }
+    return "";
+  };
+
+  const formatPackages = (packages: string) => {
+    return packages.split(",").reduce((accumulator, singlePackage) =>  `${accumulator}'${singlePackage}',` , "");
+  }
+
   let settings: any = {
     id: element.id,
     height: parseInt(element.getAttribute("data-height") || "auto", 10),
@@ -31,7 +42,8 @@ export default (element: HTMLDivElement, hub: Hub) => {
     const exercise = JSON.parse(atob(decodeURIComponent(element.textContent)));
     settings.hint = exercise.hint;
     settings.language = exercise.language;
-    settings.pre_exercise_code = exercise.pre_exercise_code;
+    settings.lang_version = exercise.lang_version;
+    settings.pre_exercise_code = getPackages(exercise.packages) + exercise.pre_exercise_code;
     settings.sample_code = exercise.sample || exercise.sample_code;
     settings.sct = exercise.sct;
     settings.solution = exercise.solution;
@@ -66,7 +78,8 @@ export default (element: HTMLDivElement, hub: Hub) => {
     Object.assign(settings, {
       hint: getHint(),
       language: (element.getAttribute("data-lang") || "r") as Language,
-      pre_exercise_code: getText("pre-exercise-code"),
+      lang_version: element.getAttribute("lang-version"),
+      pre_exercise_code: getPackages(element.getAttribute("packages")) + getText("pre-exercise-code"),
       sample_code: getText("sample-code"),
       sct: getText("sct"),
       solution: getText("solution"),

--- a/src/index.html
+++ b/src/index.html
@@ -493,5 +493,23 @@
       </div>
     </div>
 
+    <div class="exercise">
+      <div class="title">
+        <h2>Python in DataCamp Light 3</h2>
+        <p>In the HTML code for this exercise you can specify the packages to import and the Python version you want to use.</p>
+      </div>
+      <div data-datacamp-exercise data-lang="python" lang-version="3.6" packages="pandas==0.24.1, alabaster==0.7.12" data-height="auto">
+        <code data-type="pre-exercise-code"></code>
+        <code data-type="sample-code">
+        import pandas, sys
+
+        print("PANDAS VERSION:", pandas.__version__)
+        print("PYTHON VERSION:", sys.version)
+        </code>
+        <code data-type="solution"></code>
+        <code data-type="sct"></code>
+        <div data-type="hint">Just press 'Run'.</div>
+      </div>
+
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -498,7 +498,7 @@
         <h2>Python in DataCamp Light 3</h2>
         <p>In the HTML code for this exercise you can specify the packages to import and the Python version you want to use.</p>
       </div>
-      <div data-datacamp-exercise data-lang="python" lang-version="3.6" packages="pandas==0.24.1, alabaster==0.7.12" data-height="auto">
+      <div data-datacamp-exercise data-lang="python" data-lang-version="3.6" data-packages="pandas==0.24.1, alabaster==0.7.12" data-height="auto">
         <code data-type="pre-exercise-code"></code>
         <code data-type="sample-code">
         import pandas, sys

--- a/src/redux/backend-session/index.spec.ts
+++ b/src/redux/backend-session/index.spec.ts
@@ -5,9 +5,9 @@ import { AnyAction as Action } from "typescript-fsa";
 import { marbles } from "rxjs-marbles";
 import { Observable } from "rxjs/Observable";
 
-import pm from "../helpers/pluginManager";
-import { viewsStart } from "./view";
-import { setId } from "./exercise";
+import pm from "../../helpers/pluginManager";
+import { viewsStart } from "../view";
+import { setId } from "../exercise";
 
 import reducer, {
   BackendSessionState,
@@ -19,8 +19,8 @@ import reducer, {
   muxRegistered,
   id$,
   readyAgain$,
-  guardOnBackendError,
-} from "./backend-session";
+  guardOnBackendError
+} from ".";
 
 describe("state", () => {
   test("should exist", () => {
@@ -205,4 +205,5 @@ describe("epics", () => {
       store.getActions().find(action => action.type === startSession.type)
     ).toBeDefined();
   });
+
 });

--- a/src/redux/backend-session/index.ts
+++ b/src/redux/backend-session/index.ts
@@ -34,7 +34,8 @@ import {
   selectId,
   selectLanguage,
   selectListener,
-  selectLangVersion
+  selectLangVersion,
+  selectPackages
 } from "../exercise";
 
 import { State } from "../";
@@ -251,7 +252,8 @@ export const epicRegisterMux: Epic<Action, State> = (action$, store) =>
       const language = selectLanguage(store.getState());
       const imageTag = selectImageTag(
         language,
-        selectLangVersion(store.getState())
+        selectLangVersion(store.getState()),
+        selectPackages(store.getState())
       );
       registerMux(language, dclId);
 
@@ -302,7 +304,8 @@ export const epicStartSession: Epic<Action, State> = (action$, store) => {
         selectBackendSessionCountPostNewSession(store.getState()) === 1;
       const imageTag = selectImageTag(
         startSessionAction.payload.language,
-        selectLangVersion(store.getState())
+        selectLangVersion(store.getState()),
+        selectPackages(store.getState())
       );
       const options = {
         language: startSessionAction.payload.language,
@@ -353,7 +356,8 @@ export const epicRestartSession: Epic<Action, State> = (action$, store) =>
       id: selectId(store.getState()),
       image_tag: selectImageTag(
         selectLanguage(store.getState()),
-        selectLangVersion(store.getState())
+        selectLangVersion(store.getState()),
+        selectPackages(store.getState())
       ),
       force_new: true
     })

--- a/src/redux/backend-session/index.ts
+++ b/src/redux/backend-session/index.ts
@@ -27,20 +27,25 @@ import Multiplexer, {
   Language,
   PLUGIN_NAME as MUX_NAME,
   SessionOutput,
-  SessionStatus,
+  SessionStatus
 } from "@datacamp/multiplexer-client";
 
-import { State } from "./";
-import { setId } from "./exercise";
-import { viewsStart } from "./view";
-import { selectId, selectLanguage, selectListener } from "./exercise";
+import {
+  selectId,
+  selectLanguage,
+  selectListener,
+  selectLangVersion
+} from "../exercise";
 
-import ExerciseService from "../helpers/baseExercise";
-import getOutputAction from "../helpers/output";
-import pluginManager, { getMux } from "../helpers/pluginManager";
-import uuid from "../helpers/uuid";
+import { State } from "../";
+import { setId } from "../exercise";
+import { viewsStart } from "../view";
+import selectImageTag from "./selectImageTag";
+import ExerciseService from "../../helpers/baseExercise";
+import pluginManager, { getMux } from "../../helpers/pluginManager";
+import uuid from "../../helpers/uuid";
 
-import config from "../config";
+import config from "../../config";
 
 /*
  * Actions */
@@ -51,6 +56,7 @@ export const startSession = createAction<{
   language: Language;
   id: string;
   force_new: boolean;
+  image_tag: string;
   initCommands?: Command;
 }>("EPIC_START_SESSION");
 
@@ -89,7 +95,7 @@ export const BACKEND_STATUS: { [x: string]: SessionStatus } = {
   BROKEN: { status: "broken", text: "Session Broken" },
   BUSY: { status: "busy", text: "Session Busy" },
   NONE: { status: "none", text: "" },
-  READY: { status: "ready", text: "Workspace Ready" },
+  READY: { status: "ready", text: "Workspace Ready" }
 };
 
 export interface IBackendSessionState {
@@ -103,7 +109,7 @@ const initialState: IBackendSessionState = {
   countPostNewSession: 0,
   isInitSession: false,
   status: BACKEND_STATUS.NONE,
-  statusCode: 0,
+  statusCode: 0
 };
 
 export class BackendSessionState extends Record(initialState) {}
@@ -164,7 +170,7 @@ export const selectBackendUIStatus = (state: State) => {
   const status = selectBackendSession(state).get("status");
   return {
     code: status.status,
-    text: status.text,
+    text: status.text
   };
 };
 
@@ -211,14 +217,14 @@ const registerMux = (language: Language, dclId: string) => {
   }
   const userInfo = {
     authentication_token: id,
-    email: `datacamp-light+${id}@datacamp.com`,
+    email: `datacamp-light+${id}@datacamp.com`
   };
   pluginManager.remove(MUX_NAME + dclId);
   pluginManager.register(MUX_NAME + dclId, Multiplexer.AsyncSession, userInfo, {
     debug: process.env.NODE_ENV === "development",
     flattenOutputs: false,
     language,
-    multiplexerUrl: config.urls.multiplexer,
+    multiplexerUrl: config.urls.multiplexer
   });
 };
 
@@ -243,6 +249,10 @@ export const epicRegisterMux: Epic<Action, State> = (action$, store) =>
       const state = store.getState();
       const dclId = selectId(store.getState());
       const language = selectLanguage(store.getState());
+      const imageTag = selectImageTag(
+        language,
+        selectLangVersion(store.getState())
+      );
       registerMux(language, dclId);
 
       const muxStateSubject$ = new BehaviorSubject(BACKEND_STATUS.NONE);
@@ -257,12 +267,13 @@ export const epicRegisterMux: Epic<Action, State> = (action$, store) =>
         Observable.of(
           startSession({
             force_new: false,
+            image_tag: imageTag,
             id: dclId,
             initCommands: {
               ...ExerciseService.prepareSubmit(state, {}),
-              command: "init",
+              command: "init"
             },
-            language,
+            language
           })
         ),
         updateBackendStatus$,
@@ -289,9 +300,14 @@ export const epicStartSession: Epic<Action, State> = (action$, store) => {
       const forceNew =
         startSessionAction.payload.force_new ||
         selectBackendSessionCountPostNewSession(store.getState()) === 1;
+      const imageTag = selectImageTag(
+        startSessionAction.payload.language,
+        selectLangVersion(store.getState())
+      );
       const options = {
         language: startSessionAction.payload.language,
         force_new: forceNew,
+        image_tag: imageTag
       };
 
       mux.start(options, startSessionAction.payload.initCommands);
@@ -317,14 +333,14 @@ export const epicSubmitCode: Epic<Action, State> = (action$, store) => {
       );
 
       getMux(dclId).input({
-        ...commandConfig,
+        ...commandConfig
       });
 
       return commandConfig;
     })
     .do(config =>
       selectListener(store.getState())("submit", {
-        code: config.code,
+        code: config.code
       })
     )
     .concatMapTo(Observable.empty());
@@ -335,6 +351,10 @@ export const epicRestartSession: Epic<Action, State> = (action$, store) =>
     startSession({
       language: selectLanguage(store.getState()),
       id: selectId(store.getState()),
-      force_new: true,
+      image_tag: selectImageTag(
+        selectLanguage(store.getState()),
+        selectLangVersion(store.getState())
+      ),
+      force_new: true
     })
   );

--- a/src/redux/backend-session/selectImageTag.spec.ts
+++ b/src/redux/backend-session/selectImageTag.spec.ts
@@ -1,0 +1,15 @@
+import selectImageTag from "./selectImageTag";
+
+describe("selectImageTag", () => {
+  test("should return the python image tag based on version chosen", () => {
+    expect(selectImageTag("python", "3.5")).toEqual("dcl-python-3.5:latest");
+  });
+
+  test("should return python3.5 tag as default if version is not recognised", () => {
+    expect(selectImageTag("python", "0.0")).toEqual("dcl-python-3.5:latest");
+  });
+
+  test("should return the empty string if language is not python", () => {
+    expect(selectImageTag("r", "3.5")).toEqual("");
+  });
+});

--- a/src/redux/backend-session/selectImageTag.spec.ts
+++ b/src/redux/backend-session/selectImageTag.spec.ts
@@ -2,14 +2,18 @@ import selectImageTag from "./selectImageTag";
 
 describe("selectImageTag", () => {
   test("should return the python image tag based on version chosen", () => {
-    expect(selectImageTag("python", "3.5")).toEqual("dcl-python-3.5:latest");
+    expect(selectImageTag("python", "3.5", "")).toEqual("dcl-python-3.5:latest");
   });
 
   test("should return python3.5 tag as default if version is not recognised", () => {
-    expect(selectImageTag("python", "0.0")).toEqual("dcl-python-3.5:latest");
+    expect(selectImageTag("python", "0.0", "")).toEqual("dcl-python-3.5:latest");
   });
 
   test("should return the empty string if language is not python", () => {
-    expect(selectImageTag("r", "3.5")).toEqual("");
+    expect(selectImageTag("r", "3.5", "")).toEqual("");
+  });
+
+  test("should return the empty string if both python version and packages are not specified in the html", () => {
+    expect(selectImageTag(null, null, "")).toEqual("");
   });
 });

--- a/src/redux/backend-session/selectImageTag.ts
+++ b/src/redux/backend-session/selectImageTag.ts
@@ -1,10 +1,14 @@
 import { Language } from "@datacamp/multiplexer-client";
+import * as _ from "lodash";
 
-function selectImageTag(language: Language, version: string) {
+function selectImageTag(language: Language, version: string, packages: string) {
   if (language === "python") {
     const python_versions = ["3.5", "3.6"];
     const default_version = "3.5";
 
+    if (_.isNil(packages) && _.isNil(version)) {
+      return "";
+    }
     if (python_versions.includes(version)) {
       return `dcl-python-${version}:latest`;
     }

--- a/src/redux/backend-session/selectImageTag.ts
+++ b/src/redux/backend-session/selectImageTag.ts
@@ -1,0 +1,19 @@
+import { Language } from "@datacamp/multiplexer-client";
+
+function selectImageTag(language: Language, version: string) {
+  if (language === "python") {
+    const python_versions = ["3.5", "3.6"];
+    const default_version = "3.5";
+
+    if (python_versions.includes(version)) {
+      return `dcl-python-${version}:latest`;
+    }
+    console.log(
+      `Python version not found. Using default Python ${default_version}. Available versions are: " ${python_versions}`
+    );
+    return `dcl-python-${default_version}:latest`;
+  }
+  return "";
+}
+
+export default selectImageTag;

--- a/src/redux/exercise.ts
+++ b/src/redux/exercise.ts
@@ -79,7 +79,7 @@ const initialState: IExerciseState = {
   showSolutionButton: false,
   showRunButton: false,
   shellProxy: "",
-  listener: () => {},
+  listener: () => {}
 };
 
 export class ExerciseState extends Record(initialState) {}
@@ -94,7 +94,7 @@ const reducer = reducerWithInitialState(new ExerciseState())
   .case(showHint, state =>
     state.set("feedback", {
       content: state.get("hint"),
-      type: "info",
+      type: "info"
     })
   )
   .case(updateCode, (state, content) => state.set("code", content))
@@ -126,6 +126,9 @@ export const selectLanguage = (state: State) =>
 
 export const selectLangVersion = (state: State) =>
   selectExercise(state).get("lang_version");
+
+export const selectPackages = (state: State) =>
+  selectExercise(state).get("packages");
 
 export const selectPreExerciseCode = (state: State) =>
   selectExercise(state).get("pre_exercise_code");
@@ -160,7 +163,7 @@ export const epicPublishFeedback: Epic<Action, State> = (action$, store) =>
     .do(({ payload }) =>
       selectListener(store.getState())("feedback", {
         correct: payload.type === "success",
-        content: payload.content,
+        content: payload.content
       })
     )
     .concatMapTo(Observable.empty());

--- a/src/redux/exercise.ts
+++ b/src/redux/exercise.ts
@@ -22,6 +22,7 @@ export const setId = createAction<string>("SET_ID");
 
 export const setExercise = createAction<{
   language: Language;
+  lang_version?: string;
   hint?: string;
   pre_exercise_code?: string;
   sample_code?: string;
@@ -49,6 +50,8 @@ export interface IExerciseState {
   hint: string;
   id: string;
   language: Language;
+  lang_version: string;
+  packages: string;
   pre_exercise_code: string;
   sample_code: string;
   sct: string;
@@ -66,6 +69,8 @@ const initialState: IExerciseState = {
   hint: "",
   id: "",
   language: "r",
+  lang_version: "",
+  packages: "",
   pre_exercise_code: "",
   sample_code: "",
   sct: "",
@@ -118,6 +123,9 @@ export const selectId = (state: State) => selectExercise(state).get("id");
 
 export const selectLanguage = (state: State) =>
   selectExercise(state).get("language");
+
+export const selectLangVersion = (state: State) =>
+  selectExercise(state).get("lang_version");
 
 export const selectPreExerciseCode = (state: State) =>
   selectExercise(state).get("pre_exercise_code");


### PR DESCRIPTION
Enabled selection of packages and Python versions through the html of the DCL exercise, using the attributes "packages" and "lang-version" on the tag "data-datacamp-exercise".