### PR TITLE
[WL-3239] feat: add utmSource and utmCampaign parameters

### DIFF
--- a/src/boot.tsx
+++ b/src/boot.tsx
@@ -27,6 +27,9 @@ export default (element: HTMLDivElement, hub: Hub) => {
     height: parseInt(element.getAttribute("data-height") || "auto", 10),
   };
 
+  const utmSource = element.getAttribute("data-utm-source") || undefined;
+  const utmCampaign = element.getAttribute("data-utm-campaign") || undefined;
+
   if (element.getAttribute("data-encoded")) {
     const exercise = JSON.parse(atob(decodeURIComponent(element.textContent)));
     settings.hint = exercise.hint;
@@ -95,7 +98,12 @@ export default (element: HTMLDivElement, hub: Hub) => {
     return (
       <AppContainer>
         <Provider store={store}>
-          <App height={settings.height} language={settings.language} />
+          <App
+            height={settings.height}
+            language={settings.language}
+            utmSource={utmSource}
+            utmCampaign={utmCampaign}
+          />
         </Provider>
       </AppContainer>
     );

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -83,6 +83,8 @@ export interface IAppProps extends React.Props<App> {
   language?: string;
   height?: number;
   nPlots?: number;
+  utmSource?: string;
+  utmCampaign?: string;
 }
 
 interface IAppState {
@@ -317,6 +319,8 @@ export class App extends React.Component<IAppProps, IAppState> {
           <Footer
             onShowSolution={this.showSolutionTab}
             showSolutionButton={this.state.solutionButtonVisible}
+            utmSource={this.props.utmSource}
+            utmCampaign={this.props.utmCampaign}
           />
         </div>
       </Provider>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -75,22 +75,11 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
     });
   }
 
-  createURL = (utmSource: string, utmCampaign: string) => {
-    const url = new URL("https://www.datacamp.com/");
-    const params = new URLSearchParams({
-      utm_source: utmSource,
-      utm_campaign: utmCampaign,
-    });
-    url.search = params.toString();
-    return url.toString();
-  };
-
   public render() {
-    const datacampUrl = this.createURL(
-      this.props.utmSource,
-      this.props.utmCampaign
-    );
-
+    const { utmSource, utmCampaign } = this.props;
+    const baseUrl = "https://www.datacamp.com/";
+    const queryParams = `utm_source=${utmSource}&utm_campaign=${utmCampaign}`;
+    const datacampUrl = `${baseUrl}?${queryParams}`;
     return (
       <div className={styles.footer}>
         {this.props.hint ? (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -75,7 +75,22 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
     });
   }
 
+  createURL = (utmSource: string, utmCampaign: string) => {
+    const url = new URL("https://www.datacamp.com/");
+    const params = new URLSearchParams({
+      utm_source: utmSource,
+      utm_campaign: utmCampaign,
+    });
+    url.search = params.toString();
+    return url.toString();
+  };
+
   public render() {
+    const datacampUrl = this.createURL(
+      this.props.utmSource,
+      this.props.utmCampaign
+    );
+
     return (
       <div className={styles.footer}>
         {this.props.hint ? (
@@ -122,8 +137,7 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
           className={styles.restart}
         />
         <a
-          href={`https://www.datacamp.com/?utm_source=${this.props
-            .utmSource}&utm_campaign=${this.props.utmCampaign}`}
+          href={datacampUrl}
           className={styles.logo}
           title="Powered by DataCamp"
           target="_blank"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,6 +22,8 @@ export interface IFooterProps extends React.Props<Footer> {
   showRunButton?: boolean;
   sct?: string;
   language?: string;
+  utmSource?: string;
+  utmCampaign?: string;
 }
 
 interface IFooterState {
@@ -37,6 +39,8 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
     isSessionBusy: false,
     showSolutionButton: false,
     showRunButton: false,
+    utmSource: "datacamp_light",
+    utmCampaign: "powered_by_datacamp",
   };
 
   public displayName: string = "Footer";
@@ -118,7 +122,8 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
           className={styles.restart}
         />
         <a
-          href="https://www.datacamp.com/?utm_source=datacamp_light&utm_campaign=powered_by_datacamp"
+          href={`https://www.datacamp.com/?utm_source=${this.props
+            .utmSource}&utm_campaign=${this.props.utmCampaign}`}
           className={styles.logo}
           title="Powered by DataCamp"
           target="_blank"


### PR DESCRIPTION
Adds 2 optional parameters that can be added at element level, data-utm-source and data-utm-campaign. The values of those will be applied to the datacamp logo link. If not supplied they will have default values. 